### PR TITLE
Allow `type` attribute for a href variable

### DIFF
--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -86,9 +86,41 @@ The value of the `Templated Href` type SHOULD be resolved as a URI-Reference per
 
 The definition is a Data Structure element `Object Type` where keys are respective URI Template variables.
 
+**NOTE:** *A href variable may include an attribute `type` which may
+contain a label for the variable type.*
+
 #### Properties
 
 - `element`: hrefVariables (string, fixed)
+
+#### Example
+
+```json
+{
+  "element": "hrefVariables",
+  "content": [
+    {
+      "element": "member",
+      "meta": {
+        "description": "Filter users only showing admins"
+      },
+      "attributes": {
+        "type": "boolean"
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "is_admin"
+        },
+        "value": {
+          "element": "string",
+          "content": "1"
+        }
+      }
+    }
+  ]
+}
+```
 
 ### Data Structure (Base API Element)
 


### PR DESCRIPTION
This PR introduces a new attributed called `type` for a href variable along with including a full example of a `HrefVariables` element.

This allows solving two problems:

1) Loss of type information, API Blueprint supports freeform text for parameter type which couldn't be represented in API Elements.
2) Incorrect re-serialisation of values such as booleans.

Previously parsers such as the API Blueprint parser Drafter cannot store the raw representation a user used for a type for example given the following parameter in an API Blueprint:

```apib
+ Parameters
    + since (datetime)
```

Without MSON Parameters, this would be treated as a string internally and serialised in API Elements as such. Inside [API Blueprint AST](https://github.com/apiaryio/api-blueprint-ast#parameter-object) the type would be available. This may be unnecessary for some types such as numerical types where they can be represented as Refract primitives:

```json
{
  "element": "hrefVariables",
  "content": [
    {
      "element": "member",
      "content": {
        "key": {
          "element": "string",
          "content": "since"
        },
        "value": {
          "element": "number"
        }
      }
    }
  ]
}
```

However in API Blueprint a parameter type is purely just freeform text, and there are no restrictions on the type values and how they would be represented in a URL. Unlike MSON where you would always serialise in a specific format so you can have expectations that booleans values may be `true` or `false`. This isn't the case in parameters as there are no standards that define how data types should be serialised in a URI. As an example:

```apib
+ Parameters
    + `is_admin`: 1 (boolean)
```

It would be fully expected that `1` is a valid value as per the API Blueprint specification. The specifications mentions no limitations on value types, and as there are no expectations on how values are serialised into URLs, it should be expected that `1` would end up in the URL if the template `/users{?is_admin}` was expanded `/users?is_admin=1`. As URIs do not have any upfront expectation of how values (boolean, number, etc) would be serialised it would be incorrect to force booleans to be `true`/`false` and serialised as either `true` or `false`.

This isn't the case at the moment in Drafter with API Elements serialisation. Since `boolean` would currently be mapped to a API Elements type boolean where `1` isn't picked up as a `true` value so the default would be `false`. Also, this means that tools would serialise the boolean value as `true` or `false` instead of what the user intended as `0` or `1`. Ideally users would specify an enum in API Blueprint, however that isn't nice because API Blueprint would currently require you to duplicate the enum type. In future this could be much more elegant when a user could declare a parameter boolean type of enum and reuse it.

```apib
+ Parameters
    + `is_admin`: 1 (enum)
        + 1
         + 0
```

/c @smizell would love to get your feedback here if you have some spare time to take a look.