### PR TITLE
Move enumerations to enumerations attribute in enum

### DIFF
--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -817,14 +817,16 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 #### Properties
 
 - `element`: enum (string, fixed)
-- `content` (array[[Data Structure Element][]])
+- `attributes`
+    - `enumerations` (Array Element[[Data Structure Element][]])
+- `content` ([Data Structure Element][])
 
 #### Examples
 
 ##### MSON
 
 ```
-- tag (enum[string])
+- tag: green (enum[string])
     - red
     - green
 ```
@@ -844,16 +846,21 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
         },
         "value": {
           "element": "enum",
-          "content": [
-            {
-              "element": "string",
-              "content": "red"
-            },
-            {
-              "element": "string",
-              "content": "green"
+          "attributes": {
+            "enumerations": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "red"
+                },
+                {
+                  "element": "string",
+                  "content": "green"
+                }
+              ]
             }
-          ]
+          }
         }
       }
     }


### PR DESCRIPTION
Enum was designed a little different to other data structure elements. Other Data Structure elements contain a value of the data structure under content, however `enum` doesn't contain a single value that the enum was representing but instead all the possible values (enumerations) that may be inside the enum.

This pull request changes `enum` so that the enum content contains the single selected enumeration, and move the available enumerations to the enumerations attribute. This allows the element to follow the normal data structure rules regarding the type for `default` and `samples` where they would match the same type as the data structure elements content.

#### Examples

To describe an enum with 4 possible string values, `north`, `east`, `south`, `west` we could represent that as an enum element as follows:

```json
{
  "element": "enum",
  "attributes": {
    "enumerations": {
      "element": "array",
      "content": [
        {
          "element": "string",
          "content": "north"
        },
        {
          "element": "string",
          "content": "east"
        },
        {
          "element": "string",
          "content": "south"
        },
        {
          "element": "string",
          "content": "west"
        }
      ]
    }
  }
}
```

To describe the same enum with the four directions, and to provide a default value of `north`. We can represent that as an enum as follows:

```json
{
  "element": "enum",
  "attributes": {
    "default": {
      "element": "string",
      "content": "north"
    },
    "enumerations": {
      "element": "array",
      "content": [
        {
          "element": "string",
          "content": "north"
        },
        {
          "element": "string",
          "content": "east"
        },
        {
          "element": "string",
          "content": "south"
        },
        {
          "element": "string",
          "content": "west"
        }
      ]
    }
  }
}
```

To describe the same enum, but also to provide a selected sample value of `south`:

```json
{
  "element": "enum",
  "attributes": {
    "default": {
      "element": "string",
      "content": "north"
    },
    "enumerations": {
      "element": "array",
      "content": [
        {
          "element": "string",
          "content": "north"
        },
        {
          "element": "string",
          "content": "east"
        },
        {
          "element": "string",
          "content": "south"
        },
        {
          "element": "string",
          "content": "west"
        }
      ]
    }
  },
  "content": {
      "element": "string",
      "content": "south"
    }
}
```