### PR TITLE
Rewrite the tooling page to reflect current reality

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,33 +1,45 @@
-# Tools
+# Tooling
 
-## [Fury](https://github.com/apiaryio/fury.js)
-
-Fury is a library for parsing API description documents and return API Elements.
+There are various API Elements tools available to interact and parse API
+Description Documents.
 
 ## [API Description Parsing Service](http://docs.apiblueprintapi.apiary.io/#reference)
 
-API Description Parsing Serice (formerly API Bluerpint API) is a hosted service that takes API Blueprint as an input and return API Elements.
+API Description Parsing Serice (formerly API Bluerpint API) is a hosted service
+that takes API Description documents such as API Blueprint or Swagger 2.0 as
+input and returns API Elements.
 
-## [Drafter](https://github.com/apiaryio/drafter)
+## JavaScript
+
+### [Fury](https://github.com/apiaryio/fury.js)
+
+Fury is a library for validating and parsing API description documents, Furys
+API provides [API Element JS](https://api-elements-js.readthedocs.io/) objects.
+
+### [API Element JS](https://api-elements-js.readthedocs.io/)
+
+The API Elements JS Package provides an interface for querying and interacting
+with API Elements. This library can be used in conjunction with Fury to handle
+parsing of API Description documents into API Elements.
+
+## Python
+
+### [refract.py](https://github.com/kylef/refract.py)
+
+A Python library for interacting with Refract and API Element in Python.
+
+---
+
+## API Blueprint
+
+The API Blueprint ecosystem heavily uses API Elements under the hood. Although
+we would recommend interacting with API Elements using the JavaScript tooling
+above as it is generic and not API Blueprint specific.
+
+### [Drafter](https://github.com/apiaryio/drafter)
 
 Drafter is a library for parsing API Blueprint documents and return parse results in API Elements.
 
-## [Protagonist](https://github.com/apiaryio/protagonist)
+### [Drafter JS](https://github.com/apiaryio/drafter-npm)
 
-Protagonist is a Node.js wrapper for the Drafter library.
-
-## [Lodash API Description](https://github.com/apiaryio/lodash-api-description)
-
-A JavaScript library provides utility functions for consuming an API Elements document.
-
-## [Query Tool](https://github.com/apiaryio/refract-query)
-
-A tool for querying a Refract or API Elements document.
-
-## [Minim API Definition](https://github.com/refractproject/minim-api-description/)
-
-This JavaScript tool utilizes [Minim](https://github.com/refractproject/minim) for building and consuming API Elements.
-
-## [refract.py](https://github.com/kylef/refract.py)
-
-A Python library for interacting with Refract and API Element.
+Drafter JS is a JavaScript interface to Drafter and can be used in Node.JS or natively in a browser.


### PR DESCRIPTION
I've prompted the JavaScript interfaces that we maintain, dropped the unsupported legacy tools like lodash-query and de-coupled the API Blueprint specific tooling as a separate section.