### PR TITLE
Add extensions registry containing OAS3 extensions

### DIFF
--- a/docs/extensions/index.rst
+++ b/docs/extensions/index.rst
@@ -1,0 +1,7 @@
+Extensions Registry
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   oas/index

--- a/docs/extensions/oas/extensions.rst
+++ b/docs/extensions/oas/extensions.rst
@@ -1,0 +1,46 @@
+OpenAPI Specification Extensions
+================================
+
+This document is a profile for storing OpenAPI Specification Extensions within
+an API Element extension.
+
+The contents of an extension element with this profile will contain the
+contents of the extensions is an object containing any vendor extensions found in
+the underlying Swagger Description document.
+
+For example, if a vendor extension with the key ``x-sts`` with a value true was
+found in an OpenAPI document, it may be represented using the following
+extension element::
+
+    {
+        "element": "extension",
+        "meta": {
+            "links": [
+                {
+                    "element": "link",
+                    "attributes": {
+                      "relation": "profile",
+                      "href": "https://apielements.org/extensions/oas/extensions/"
+                    }
+                }
+            ]
+        },
+        "content": {
+            "element": "object",
+            "content": [
+                {
+                    "element": "member",
+                    "content": {
+                        "key": {
+                            "element": "string",
+                            "content": "sts"
+                        },
+                        "value": {
+                            "element": "boolean",
+                            "content": true
+                        }
+                    }
+                }
+            ]
+        }
+    }

--- a/docs/extensions/oas/index.rst
+++ b/docs/extensions/oas/index.rst
@@ -1,0 +1,7 @@
+OpenAPI Specification Extensions
+================================
+
+.. toctree::
+   :maxdepth: 1
+
+   extensions

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ This documentation conforms to [RFC 2119][], which says:
    examples
    tools
    additional-information
+   extensions/index
 ```
 
 ## License


### PR DESCRIPTION
As per discussion in https://github.com/apiaryio/fury-adapter-swagger/pull/177/files#r191606760

There are some slight alterations to the extension compared to the previous version at https://help.apiary.io/profiles/api-elements/vendor-extensions/.

- The content is now an object element, values are elements.
- The `x-` prefix on the keys are stripped. I don't think thats necessary to have them.

/c @abacaphiliac