### PR TITLE
Unify the term for transaction with the rest of the specs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -43,7 +43,7 @@ It is also helpful to know the relationship between elements. The list below sho
         - Category (Group of Transition Elements)
         - Transition
             - Copy
-            - Transaction
+            - HTTP Transaction
                 - Copy
                 - HTTP Request
                     - Copy


### PR DESCRIPTION
Historically I think we were using HTTP Transaction everywhere as well as [httpTransaction](https://api-elements.readthedocs.io/en/latest/element-definitions.html#http-transaction-array). So I think this is a bug in the Relationship of Elements section.