### PR TITLE
feat: support "host" resources

### DIFF
--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1311,7 +1311,9 @@ transitions.
 - `"api"` - Category is a API top-level group.
 - `"authSchemes"` - Category is a group of authentication and authorization scheme definitions.
 - `"dataStructures"` - Category is a set of data structures.
-- `"hosts"` - Category is a set of servers.
+- `"hosts"` - Category of [Resource][] or [Transition][] which implicitly contain the respective `host` classification.
+  _See the classifications in [Resource][] and [Transition][] for further semantics._
+
 - `"resourceGroup"` - Category is a set of resources.
 - `"scenario"` - Category is set of steps.
 - `"transitions"` - Category is a group of transitions.

--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1126,11 +1126,17 @@ The Resource representation with its available transitions and its data.
 
 - `element` - `"resource"`
 - `attributes`
+    - `hosts` ([Array][][[Resource][]]).
+    
+        Resources in the hosts attribute SHOULD implicitly be treated as they have the `host` resource classification.
+        If `hosts` attribute is specified at the Root, Resource, or Transition level, it will be overidden by this value.
+        _See `host` classification in [Resource][] for further semantics._
+
     - `href` ([Templated Href][]) - URI Template for this resource.
     - `hrefVariables` ([Href Variables][]) - URI Template variables.
 - `content` (array)
     - ([Copy][]) - Textual information of this resource in API Description.
-    - ([Category][]) - A group of Transition elements
+    - ([Category][]) - A group of Transition elements.
     - ([Transition][]) - State transitions available for this resource.
 
         The `content` MAY include multiple `Transition` elements.
@@ -1141,7 +1147,9 @@ The Resource representation with its available transitions and its data.
 
 #### Classifications
 
-- `"host"` - Resource is a server.
+- `"host"` - A host resource represents the "root" of the API resource.
+    The resource href MAY be append to the host href to create a absolute URI.
+    A resource that has a `host` classification MUST be a root component of a URI.
 
 #### Example
 
@@ -1199,11 +1207,17 @@ Note: At the moment only the HTTP protocol is supported.
 
 - `element` - `"transition"`
 - `attributes`
-    - `relation` - ([String][]) - Link relation type as specified in [RFC 5988][].
+    - `contentTypes` ([Array][][[String][]]) - A collection of content types that MAY be used for the transition.
 
-        The value of `relation` attribute SHOULD be interpreted as a link relation
-        between transition's parent resource and the transition's target resource
-        as specified in the `href` attribute.
+    - `data` ([Data Structure][]) - Data structure describing the transition's `Request` `message-body` unless overridden.
+
+        Definition of any input message-body attribute for this transition.
+
+    - `hosts` ([Array][][[Transition][]]).
+    
+        Transitions in the hosts attribute SHOULD implicitly be treated as they have the `host` transition classification.
+        If `hosts` attribute is specified at the Root, Resource, or Transition level, it will be overidden by this value.
+        _See `host` classification in [Transition][] for further semantics._
 
     - `href` ([Templated Href][]) - URI template for this transition.
 
@@ -1220,12 +1234,12 @@ Note: At the moment only the HTTP protocol is supported.
         If `href` and `hrefVariables` attributes aren't set, the parent `resource`
         element `hrefVariables` SHOULD be used to resolve the transition input
         parameters.
+    
+    - `relation` - ([String][]) - Link relation type as specified in [RFC 5988][].
 
-    - `data` ([Data Structure][]) - Data structure describing the transition's `Request` `message-body` unless overridden.
-
-        Definition of any input message-body attribute for this transition.
-
-    - `contentTypes` ([Array][][[String][]]) - A collection of content types that MAY be used for the transition.
+        The value of `relation` attribute SHOULD be interpreted as a link relation
+        between transition's parent resource and the transition's target resource
+        as specified in the `href` attribute.
 - `content` (array)
     - ([Copy][]) - Textual information of this transition in API Description.
     - ([HTTP Transaction](#http-transaction-array))
@@ -1235,6 +1249,12 @@ Note: At the moment only the HTTP protocol is supported.
 
         For the time being this reference document defines only HTTP-specific transaction
         data structures.
+
+#### Classifications
+
+- `"host"` - A host transition represents the "root" of the API transition. 
+    The transition href MAY be append to the host href to create a absolute URI.
+    A transition that has a `host` classification MUST be a root component of a URI.
 
 #### Example
 

--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1118,6 +1118,53 @@ Data structure definition using Data Structure elements.
 - `"messageBody"` - Asset is an example of message-body
 - `"messageBodySchema"` - Asset is a schema for message-body
 
+### Server ([Object][])
+
+Subtype of [Object][] representing a server.
+
+#### Template
+
+- `element` - `"server"`
+- `attributes`
+    - `href` ([Templated Href][]) - URI Template for this server.
+    - `hrefVariables` ([Href Variables][]) - URI Template variables.
+
+#### Example
+
+```json
+{
+  "element": "server",
+  "meta": {
+    "description": {
+      "element": "string",
+      "content": "Description of the server."
+    }
+  },
+  "attributes": {
+    "href": {
+      "element": "string",
+      "content": "{basePath}://example.com/"
+    },
+    "hrefVariables": {
+      "element": "hrefVariables",
+      "content": [
+        {
+          "element": "member",
+          "content": {
+            "key": {
+              "element": "string",
+              "content": "basePath"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "content": [
+  ]
+}
+```
+
 ### Resource
 
 The Resource representation with its available transitions and its data.
@@ -1289,7 +1336,8 @@ transitions.
 - `"dataStructures"` - Category is a set of data structures.
 - `"scenario"` - Category is set of steps.
 - `"transitions"` - Category is a group of transitions.
-- `"authSchemes"` - Category is a group of authentication and authorization scheme definitions
+- `"authSchemes"` - Category is a group of authentication and authorization scheme definitions.
+- `"servers"` - Category is a group of servers.
 
 #### Example
 

--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1126,11 +1126,12 @@ The Resource representation with its available transitions and its data.
 
 - `element` - `"resource"`
 - `attributes`
-    - `hosts` ([Array][][[Resource][]]).
-    
-        Resources in the hosts attribute SHOULD implicitly be treated as they have the `host` resource classification.
-        If `hosts` attribute is specified at the Root, Resource, or Transition level, it will be overidden by this value.
-        _See `host` classification in [Resource][] for further semantics._
+    - `hosts` ([Array][][[Resource](#Resource)]).
+
+        Optional list of host resources. Every entry SHALL be interpreted as if classified as `host`.
+        _See `host` classification in [Resource](#Resource) for further semantics._
+
+        Overrides any otherwise relevant `hosts` definitions.
 
     - `href` ([Templated Href][]) - URI Template for this resource.
     - `hrefVariables` ([Href Variables][]) - URI Template variables.
@@ -1213,11 +1214,13 @@ Note: At the moment only the HTTP protocol is supported.
 
         Definition of any input message-body attribute for this transition.
 
-    - `hosts` ([Array][][[Transition][]]).
+    - `hosts` ([Array][][[Resource](#Resource)]).
     
-        Transitions in the hosts attribute SHOULD implicitly be treated as they have the `host` transition classification.
-        If `hosts` attribute is specified at the Root, Resource, or Transition level, it will be overidden by this value.
-        _See `host` classification in [Transition][] for further semantics._
+        Optional list of host resources. Every entry SHALL be interpreted as if classified as `host`.
+
+        _See `host` classification in [Resource](#Resource) for further semantics._
+
+        All [Resource](#Resource)s nested under the [Transition][]'s `content` SHALL interpret this `hosts` definition as their own, unless it is overridden by another `hosts` definition on the path to the [Resource](#Resource) element.
 
     - `href` ([Templated Href][]) - URI template for this transition.
 
@@ -1249,12 +1252,6 @@ Note: At the moment only the HTTP protocol is supported.
 
         For the time being this reference document defines only HTTP-specific transaction
         data structures.
-
-#### Classifications
-
-- `"host"` - A host transition represents the "root" of the API transition. 
-    The transition href MAY be append to the host href to create a absolute URI.
-    A transition that has a `host` classification MUST be a root component of a URI.
 
 #### Example
 
@@ -1311,8 +1308,9 @@ transitions.
 - `"api"` - Category is a API top-level group.
 - `"authSchemes"` - Category is a group of authentication and authorization scheme definitions.
 - `"dataStructures"` - Category is a set of data structures.
-- `"hosts"` - Category of [Resource][] or [Transition][] which implicitly contain the respective `host` classification.
-  _See the classifications in [Resource][] and [Transition][] for further semantics._
+- `"hosts"` - Category of [Resource][]s interpreted as a list of host resources of an API. Every entry SHALL be interpreted as if classified as `host`.
+
+_See `host` classification in [Resource][] for further semantics._
 
 - `"resourceGroup"` - Category is a set of resources.
 - `"scenario"` - Category is set of steps.

--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1141,7 +1141,7 @@ The Resource representation with its available transitions and its data.
 
 #### Classifications
 
-- `"hosts"` - Resource is a set of servers.
+- `"host"` - Resource is a server.
 
 #### Example
 

--- a/docs/element-definitions.md
+++ b/docs/element-definitions.md
@@ -1118,53 +1118,6 @@ Data structure definition using Data Structure elements.
 - `"messageBody"` - Asset is an example of message-body
 - `"messageBodySchema"` - Asset is a schema for message-body
 
-### Server ([Object][])
-
-Subtype of [Object][] representing a server.
-
-#### Template
-
-- `element` - `"server"`
-- `attributes`
-    - `href` ([Templated Href][]) - URI Template for this server.
-    - `hrefVariables` ([Href Variables][]) - URI Template variables.
-
-#### Example
-
-```json
-{
-  "element": "server",
-  "meta": {
-    "description": {
-      "element": "string",
-      "content": "Description of the server."
-    }
-  },
-  "attributes": {
-    "href": {
-      "element": "string",
-      "content": "{basePath}://example.com/"
-    },
-    "hrefVariables": {
-      "element": "hrefVariables",
-      "content": [
-        {
-          "element": "member",
-          "content": {
-            "key": {
-              "element": "string",
-              "content": "basePath"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "content": [
-  ]
-}
-```
-
 ### Resource
 
 The Resource representation with its available transitions and its data.
@@ -1185,6 +1138,10 @@ The Resource representation with its available transitions and its data.
     - ([Data Structure][]) - Data structure representing the resource.
 
         The `content` MUST NOT include more than one `Data Structure`.
+
+#### Classifications
+
+- `"hosts"` - Resource is a set of servers.
 
 #### Example
 
@@ -1332,12 +1289,12 @@ transitions.
 #### Classifications
 
 - `"api"` - Category is a API top-level group.
-- `"resourceGroup"` - Category is a set of resources.
+- `"authSchemes"` - Category is a group of authentication and authorization scheme definitions.
 - `"dataStructures"` - Category is a set of data structures.
+- `"hosts"` - Category is a set of servers.
+- `"resourceGroup"` - Category is a set of resources.
 - `"scenario"` - Category is set of steps.
 - `"transitions"` - Category is a group of transitions.
-- `"authSchemes"` - Category is a group of authentication and authorization scheme definitions.
-- `"servers"` - Category is a group of servers.
 
 #### Example
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,6 +37,7 @@ It is also helpful to know the relationship between elements. The list below sho
     - Data Structure
     - Category (Group of Resource Elements)
     - Category (Group of Authentication and Authorization Scheme Definitions)
+    - Category (Group of Resource Elements representing hosts)
     - Resource
         - Copy
         - Data Structure


### PR DESCRIPTION
Update the specification at to include "Server Element" structure described by OAS 3 format (https://swagger.io/docs/specification/api-host-and-base-path/).

As reported on Swagger website:

> "In OpenAPI 3.0, you use the `servers` array to specify one or more base URLs for your API. `servers` replaces the `host`, `basePath` and `schemes` keywords used in OpenAPI 2.0. Each server has an `url` and an optional Markdown-formatted `description`."

In OAS 3.0 a simple server looks like this:

```
servers:
  - url: '{protocol}://api.example.com'
    description: 'Description of the server'
    variables:
      protocol:
        enum:
          - http
          - https
        default: https
```

In Api Elements a server should contain a `href` and optionally `hrefVariables`.
A simple OAS3 server would map to a server element like this:

```
element: server
meta:
  description: Production
attributes:
  href: https://example.com/
```

For more information about the design please check the following link → https://github.com/apiaryio/api-elements/issues/53#issuecomment-444589557

UPDATE
→ after talk to  @tjanc I am going to remove `server` object and introduce `hosts` classification under "Resource" and "Category"

